### PR TITLE
Documenting how to contribute

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,14 @@
 # Contributing to Cloudmarque Docs
+We encourage contributions to Cloudmarque documentation. To contribute you can either:
 
-Thanks for your interest in contributing to Cloudmarque Documentation.
+ 1. Fork the repository, make changes in your own branch, and submit a pull request (preferred)
+ 2. Open an issue on GitHub explaining the change you'd like to see
 
-We'll be updating this section soon to explain how you can contribute to the documentation, please keep an eye on our [Tech Blog](https://docs.trustmarque.com/blog) for more announcements.
+We ask you to complete an electronic _Contributor Licence Agreement_ before your pull requests are merged, and we reserve the right not to accept a Pull Request.
+
+For more information, please refer to:
+
+ * [Contribution Guide](https://docs.trustmarque.com/cloudmarque/tools/docs/)
+ * [Content and Style Guide](https://docs.trustmarque.com/cloudmarque/tools/docs/content.html)
+
+Thanks for your interest in contributing to Cloudmarque Documentation!

--- a/cloudmarque/operations/ceremony/sync.md
+++ b/cloudmarque/operations/ceremony/sync.md
@@ -11,63 +11,29 @@ In Agile (Scrum) parlance, this ceremony is referred to as a "Scrum of Scrums".
 
 ## Participants and Responsibilities 
 
- * **Team Leads**
+ * **Team Representatives**
+   One member of each delivery team should attend the Team Sync. This member does not have to be the most technically proficient person on the team.
+
+   One representative should be designated the meeting host, with responsibility for:
 
     * Schedule the meeting and manage the participant list
     * Host the meeting and run the agenda
-    * Delegate running the meeting to another team member in their absence
+    * Delegate running the meeting to another member in their absence
 
 ## Scheduling  
-_Team Sync_ should happen as often as is necessary. For some types of work, a daily 
+_Team Sync_ should happen as often as is necessary. For projects requiring large amounts of co-ordination, a daily meeting may be necessary. This meeting could be weekly, fortnightly, or even monthly.
 
 ## Example Agenda 
 
- 1. Team lead confirms participants and shares any member absences (sickness or leave) 
- 2. Team members provide a short overview of their work, covering: 
+ 1. Host confirms participants and shares any absences
+ 2. Team representatives provide a short overview of their work, covering:
 
-     1. What they did in the prior working day 
-     2. What the hope to accomplish in the coming working day 
-     3. Their blockers: any factors which will affect their ability to deliver the coming day’s work 
+     1. What they have achieved and any key learning points
+     2. What they are currently working on
+     3. Blockers: any factors putting deliveries at risk or causing inefficiencies
 
- 3. Team lead reviews the sprint burndown/up chart and leads a short team discussion regarding risks to committed work and the correctness of work item states. 
- 4. Team lead reviews any new bugs raised with the team. Bugs should be logged in [work item management](). 
- 5. Team lead confirms:
+ 3. Host leads a short discussion on where teams can collaborate to remove blockers, share knowledge, and reduce risks.
+ 4. Host confirms:
 
-     1. Any actions required to “unblock” team members 
-     2. Their actions to communicate/escalate risks to committed work 
-     3. Any actions to add new tasks, update states and complete work 
-     4. Actions to contact workstream owners and request bug prioritisation, and agree whether these should be added to the sprint 
-     5. Any items to be considered at the next retrospective 
-
-## Team Lead Guidance 
-
-The Team Lead is responsible for the effective running of the Sprint Daily Standup, and as such has a lot of latitude to run these recurring meetings as they see fit, including making exceptions to all the guidance below. 
-
-This guidance is included to help the Team Lead run the Standup effectively. Treating these as unbreakable rules is likely to be counter-productive, and the role of the Team Lead is to balance these principles to help their team deliver as effectively as possible. 
-
- * **Keep it short** – standup should take no more than 15 minutes. If it is taking longer than this, it is likely that too much detail is being provided by team members. 
- 
- * **Keep it focused** – the purpose of the meeting is not to exhaustively detail what work has been done but rather identify causes of delay. If an issue has arisen, the team lead should schedule a separate discussion to resolve the issue. Standup is for identifying these delays, not resolving them. 
- 
- * **Limit the audience** – the Sprint Team should include individuals who have work item deliverables in the Sprint. It should not evolve into a general update forum for all stakeholders. The exceptions to this rule are the Product Owner and Delivery Managers, who may need to attend to understand critical delivery or process issues. However, it’s unlikely that they would need to provide updates on their individual delivery progress. 
- 
- The participant list should be reviewed if updates or discussions are taking place on the call which detract from the meeting’s objective, which is to ensure delivery tasks proceed with minimum delay possible. 
- 
-
- * **Take action immediately** – after completing the standup it is likely that the team lead has a number of actions to unblock the team. These should be completed as soon as possible as they represent significant and immediate risk to the sprint team’s committed delivery. 
- 
- * **Don’t replan** – during a sprint, the committed work should not be changed. Once a sprint is planned, do not move stories to manipulate the burndown rate. 
- 
-   Adding new tasks is fine, even if they weren’t anticipated in planning. However, the source of the unplanned work should be reviewed in the Sprint Retrospective.
- 
-   Refining estimates is also fine. Reasons for significant change should be reviewed in the Sprint Retrospective, and the “Original Estimate” preserved. 
- 
- * **Keep it regular** – avoid moving the meeting around. _Standup_ is important and should not be moved to cater for attendees’ other commitments or one-off meetings. It should be regularly spaced (so that there is something to discuss!) and at a time that all Team Members are aware of. 
-
-## Aborting a sprint 
-It is possible to abort an in-flight sprint, but the circumstances in which this is appropriate are (hopefully) rare. 
-
-   * **DON’T** abort the sprint if the committed work is unlikely to be fully delivered. The reasons for the team’s overcommitment should be evaluated in the next Sprint Retrospective, and unfinished tasks carried over (based on agreed priorities) for the next sprint. 
- 
-
-   * **DO** abort the sprint if there is no work for the team to do, and there is insufficient clarity over the prioritised work in the backlog. A new [Planning]() session is the only way to resolve the situation. 
+     1. Any follow-up actions, including meetings, objectives, and attendees
+     2. Actions to communicate/escalate new risks

--- a/cloudmarque/operations/competencies/learn.md
+++ b/cloudmarque/operations/competencies/learn.md
@@ -32,7 +32,7 @@ Ideal continuous integration processes should have the following characteristics
    It is inevitable that failures will occur as part of a delivery process; learning competency should be developed to ensure that those mistakes are not repeated.
 
  - ### Impact of failure is minimised
-   The learning process involves continual exploration and mitigation of risk. If failure is unavoidable, it is often possible to instead p[minimise the impact of failure](https://en.wikipedia.org/wiki/Chaos_engineering). Effective teams are able to quantify and minimise risk by adapting to the changes they perceive in their environment, and they accomplish this within the iterative improvement cycle.
+   The learning process involves continual exploration and mitigation of risk. If failure is unavoidable, it is often possible to instead [minimise the impact of failure](https://en.wikipedia.org/wiki/Chaos_engineering). Effective teams are able to quantify and minimise risk by adapting to the changes they perceive in their environment, and they accomplish this within the iterative improvement cycle.
 
  - ### Shared understanding is developed
    The characteristics of the problem and solution space should be better understood by the delivery team as time progresses. It is important to recognise and encourage the formation and recording of this knowledge as teams and their focus inevitably change over time, and accrued collective wisdom needs to be preserved.

--- a/cloudmarque/tools/azure/install.md
+++ b/cloudmarque/tools/azure/install.md
@@ -1,14 +1,33 @@
 ---
 title: Cloudmarque PowerShell tools for Azure
+summary: Download Cloudmarque tools on your local machine to support development and experimentation scenarios.
 ---
+This guide describes how to install Cloudmarque on a development server, a typical scenario for DevOps and Cloud Engineers who need to experiment with quickly creating and destroying environments.
+
+<div class="alert alert-info" role="alert">
+  <h4 class="alert-heading">Local vs. pipeline installation</h4>
+  <p>
+    Deployments to test or production environments should be deployed via automated pipelines, typically triggered by changes to a configuration repository. The process is functionally identical to the one outlined below. The additional considerations and recommendations related to unattended deployment will be the subject of a future guide.
+  </p>
+</div>
+
+## Prerequisites
+Before installing Cloudmarque PowerShell Tools for Azure, you will need:
+
+ * PowerShell (we recommend the latest stable version of [PowerShell 7](https://github.com/PowerShell/PowerShell/releases))
+
 ## Step 1: Install
-Cloudmarque PowerShell tools for Azure is published to the [Powershell Gallery](https://www.powershellgallery.com/packages/Cloudmarque.Azure/) and can be installed like any PowerShell package:
+Cloudmarque PowerShell tools for Azure is published to the [Powershell Gallery](https://www.powershellgallery.com/packages/Cloudmarque.Azure/) and can be installed like any PowerShell package. Create a new PowerShell session and enter the following command:
 
 {% highlight powershell %}
 Install-Package -Name "Cloudmarque.Azure" -Scope CurrentUser
 {% endhighlight %}
 
-Dependencies will be automatically installed.
+![Console window showing PowerShell commands and output after installing the Cloudmarque.Azure package](/assets/images/tutorials/install/01.png)
+
+Alternatively you can omit the `Scope` parameter to install the package for all users, though you will need to be running your PowerShell console as an Administrator. Use `-Force` if you don't want to be prompted to approve the source, or where the installation may be unattended.
+
+Dependencies are specified within the package and will be automatically installed.
 
 ## Step 2: Import
 To use commands from the package, import the PowerShell module into your current session:
@@ -27,9 +46,42 @@ New-CmAzProject -Project "MyProject"
 This will create a new project in the current directory with the name "MyProject". In the project you will find the following folders:
 
   * `_names` - Contains YAML descriptions of your cloud resource naming convention
-  * `_tags` - Contains YAML descriptions of your automatic tagging convention
-  * `core` - An example YAML deployment which provisions a Core building block
+  * `*.yml` - Example YAML deployments which provision different parts of the Cloudmarque archtiecture
 
 By convention, any project-related settings reside in directories beginning with an underscore. Any resources deployed to your environment reside in directories with no underscore prefix.
 
+Alternatively you can build your project folder manually using settings from another project you have worked on, or from settings provided from tutorials or public repositories.
+
 You may wish to manage your project via source control: you should commit the whole directory to your SCCM system, for example by running `git init` in the newly created directory.
+
+## Step 4: Connecting to Azure
+Many Cloudmarque commands require your Azure Context to be set, and will gracefully fail if this is not available. Connect to your Azure subscription as you normally would, with commands similar to:
+
+``` powershell
+Connect-AzAccount
+Get-AzSubscription -SubscriptionId "<SUBSCRIPTION>"-TenantId "<TENANT>" | Set-AzContext
+```
+
+## Step 5: Set your Cloudmarque context
+Next you need to provide Cloudmarque with information about the project you are working with, including the naming conventions, tags, and deployment resources to use. We do this by setting the _Cloudmarque Azure Context_ to the project directory you created in step 3.
+
+`Set-CmAzContext -ProjectRoot "C:\Source\CloudmarqueDemo\MyDemo\"`
+
+![Console window showing PowerShell output of the Cloudmarque Context](/assets/images/tutorials/install/02.png)
+
+You can also set a range of other properties on the CmAzContext which define which environment you are operating in, and the source of the changes you are making. See the documentation for the [Set-CmAzContext](/cloudmarque/reference/commands/set-cmazcontext.html) for more information.
+
+The Cloudmarque Context retains information on the source of the deployment, repositories, and tooling versions. These are deployed as tags on resources which can be used to diagnose issues later on.
+
+While it is less important for the context to be set in development scenarios, these properties should be explicitly reviewed and configured when Cloudmarque is used in a pipeline deployment targeting controlled environments (i.e. environments where resource deployments are automated).
+
+## Step 6: Deploy sample workloads
+The first part of any cloud deployment should be [Core workloads]/cloudmarque/architecture/core/), including monitoring, automation, and key vaults. Publishing Core services provides a foundation for other services to use later. Try running the following commands:
+
+``` powershell
+New-CmAzCoreMonitor -SettingsFile "monitor.yml"
+New-CmAzCoreKeyVault -SettingsFile "keyvaults.yml"
+New-CmAzCoreBillingRule -SettingsFile "budgets.yml"
+```
+
+You are now ready to move on to designing and deploying your desired architecture, which will be the subject of a future tutorial.

--- a/cloudmarque/tools/azure/pipelines.md
+++ b/cloudmarque/tools/azure/pipelines.md
@@ -1,0 +1,9 @@
+---
+title: Deploying via Azure Pipelines
+summary: Automate deployments from source code repositories using Cloudmarque PowerShell Tools for Azure and Azure Pipelines.
+---
+This guide describes how to use Cloudmarque tooling in a more controlled context, with automated rather than manual deployments. We recommend this approach for production environments as it provides consistent repeatable quality with clear troubleshooting and issue remediation processes.
+
+Ideally, environments should be deployed sequentially to an isolated production-like test environment prior to deployment to Prodution. Some workloads are unable to support this approach, and you should [tailor your environment strategy](/cloudmarque/architecture/devops/environments.html) according the constraints of your workload and organisation.
+
+**This guide is currently incomplete, we expect to add more detail soon**

--- a/cloudmarque/tools/azure/quickstart.md
+++ b/cloudmarque/tools/azure/quickstart.md
@@ -1,3 +1,0 @@
----
-title: Quickstart 101
----

--- a/cloudmarque/tools/docs/content.md
+++ b/cloudmarque/tools/docs/content.md
@@ -1,0 +1,35 @@
+---
+title: Docs Content Standards
+summary: If you'd like to contribute to the documentation please read through these standards to understand our quality expectations.
+---
+This guide is intended to help both content contributors and Pull Request reviewers to form a shared understanding of content quality controls. While recognising that it's not possible to codify every content rule and that a measure of quality evaluation is subjective, the aim of this page is to set out the expectations and considerations when creating and editing Cloudmarque content.
+
+## Basics
+ * Run a spelling and grammar check on your contribution.
+ * Content is proudly written in British English (EN-GB):
+    - Colour, not color
+    - -zation words are -sation (e.g. specialisation, realise, etc)
+    - Licence is a noun, licensing is a verb
+ * Refer to Cloudmarque by name, no need to add "the Cloudmarque _Standard_" or "the Cloudmarque _Framework_". It's just "Cloudmarque".
+ * Refer to readers' group contexts as "organisations", not "company" or "customer".
+ * Feel free to write in a conversational second-person ("you") when contextualising solutions for the reader: we find third-person too stilted and boring.
+
+## Form
+ * Avoid long unbroken paragraphs which make it hard for users to scan for relevant content.
+ * Aim for each paragraph to relate to a single subject.
+ * Use a mix of formatting options to break up content: paragraphs, bullet and numbered lists, headings.
+ * We run a link checker on pages as part of the build process:
+    - The checker won't flag _valid links to the wrong content_: manual checks are essential!
+    - External links aren't checked automatically.
+ * Don't include scripts or external content (IFRAMES) in pages.
+ * A picture paints a thousand words: use them rather than a thousand words.
+
+## Images
+ * Create diagrams as SVGs so that they scale nicely. If you're looking for a free editor, we use and recommend [Inkscape](https://inkscape.org/).
+ * Use SVG iconography from the relevant cloud platform to create diagrams ([Azure](https://www.microsoft.com/en-gb/download/details.aspx?id=41937), [AWS](https://aws.amazon.com/architecture/icons/)).
+ * Label components and arrows directly and/or use a key to explain what components are.
+ * Ensure any `alt` tags for images have proper descriptions for accessibility tools to use.
+ * Ensure that the image makes sense in context: text paragraphs before and/or after the image should introduce or summarise what is being shown.
+ * Where possible please add comparable diagrams for different cloud platforms (AWS/Azure).
+
+We're aware that some imagery and complex content (Liquid includes) is not yet documented, or not included in the _Cloudmarque Docs_ repository. We're addressing these over time as an ongoing background task. Don't worry about where these reside for Pull Requests, we'll confirm target locations as part of the review process.

--- a/cloudmarque/tools/docs/index.md
+++ b/cloudmarque/tools/docs/index.md
@@ -1,0 +1,34 @@
+---
+title: Editing Docs
+summary: As an Open Source project we encourage contributions and feedback; here's how you can get started with documentation.
+published: false
+---
+Cloudmarque Docs is a static HTML website built using [Jekyll](https://jekyllrb.com/), the same technology which powers [GitHub Pages](https://pages.github.com/). _doc.trustmarque.com_ is hosted in Microsoft Azure, using the Cloudmarque PaaS component for [static websites](/cloudmarque/architecture/paas/web/static.html).
+
+## About content deployment
+Our publishing pipeline can be started by changes in any one of three areas:
+
+ 1. ### GitHub: Cloudmarque Docs
+    The contents of the Cloudmarque Docs Git repository are packaged raw into an Azure Pipelines artifact and published for consuption by other pipelines (see azure-pipelines.yml in the repository root for more information).
+
+ 2. ### GitHub: Cloudmarque PowerShell Tools for Azure
+    The Cloudmarque PowerShell Tools for Azure build pipeline generates documentation which is are packaged (as raw Markdown files) into an Azure Pipelines artifact .and published for use by other pipelines.
+
+ 3. ### Azure DevOps (TMS Docs Internal)
+    Our wider Documentation site content (including our blog, services, and additional help information) triggers the publishing pipeline when new changes are committed to the repository, or when a build is manually triggered.
+
+    The contents of this repository include Trustmarque branding and web assets in the form a [Jekyll site](https://jekyllrb.com/).
+
+The publishing pipeline:
+
+ * Begins by unpacking our Docs Jekyll site
+ * Imports the latest published documentation from Cloudmarque Powershell Tools for Azure
+ * Imports the latest published documentation for Cloudmarque
+ * Runs Jekyll build to turn raw assets into a static HTML website
+ * Performs validation tests
+ * Publishes the Jekyll site for consumption by further pipelines
+
+Our infrastructure pipeline is triggered by availability of a new published Jekyll site, and:
+
+ * Deploys infrastructure (a Paas Web Static site)
+ * Deploys the site content into the infrastructure

--- a/cloudmarque/tools/docs/index.md
+++ b/cloudmarque/tools/docs/index.md
@@ -1,9 +1,8 @@
 ---
-title: Editing Docs
+title: Contributing to Docs
 summary: As an Open Source project we encourage contributions and feedback; here's how you can get started with documentation.
-published: false
 ---
-Cloudmarque Docs is a static HTML website built using [Jekyll](https://jekyllrb.com/), the same technology which powers [GitHub Pages](https://pages.github.com/). _doc.trustmarque.com_ is hosted in Microsoft Azure, using the Cloudmarque PaaS component for [static websites](/cloudmarque/architecture/paas/web/static.html).
+Cloudmarque Docs is a static HTML website built using [Jekyll](https://jekyllrb.com/), the same technology which powers [GitHub Pages](https://pages.github.com/). _docs.trustmarque.com_ is hosted in Microsoft Azure, using the Cloudmarque PaaS component for [static websites](/cloudmarque/architecture/paas/web/static.html).
 
 ## About content deployment
 Our publishing pipeline can be started by changes in any one of three areas:
@@ -32,3 +31,60 @@ Our infrastructure pipeline is triggered by availability of a new published Jeky
 
  * Deploys infrastructure (a Paas Web Static site)
  * Deploys the site content into the infrastructure
+
+## Where to edit
+To edit some content, first fork the documentation repository to your own account. Clone the repository:
+
+``` bash
+git clone https://github.com/[ACCOUNT]/cloudmarque-docs.git
+```
+
+Next, create a new branch to hold your edits. Give this a clear name which describes the types of edit you want to make.
+
+If you intend to make a number of independent edits then consider creating separate branches for each set of related changes. These can then be reviewed and potentially merged in smaller chunks.
+
+``` bash
+git checkout -b [BRANCHNAME]
+```
+
+Add the main Cloudmarque repository as an upstream source. This will allow you to pull and merge any changes that are made to content while you make your edits.
+
+``` bash
+git remote add upstream https://github.com/Trustmarque/cloudmarque-docs.git
+```
+
+Pages are written in [Markdown](https://jekyllrb.com/docs/configuration/markdown/), and can be modified with any text editor. Our team use [Visual Studio Code](https://code.visualstudio.com/) (free) as our main editor, often via a browser in [Codespaces](https://online.visualstudio.com/login).
+
+Markdown pages can include HTML markup, in contiguous line blocks.
+
+When you are happy with your changes, commit them with a descriptive message:
+
+``` bash
+git commit -S -m "New wordage is of bester"
+```
+
+Push your changes to your forked repository:
+
+``` bash
+git push -u origin [BRANCHNAME]
+```
+
+## Contributing
+When you navigate to the branch on GitHub you will now see a new option to **Create pull request**. Fill in a title and then explain the changes that you've made, and why you've made them. For each pull request (PR) please include:
+
+ 1. Your motivation for making changes.
+ 2. A paragraph stating how widespread the changes are.
+ 3. Whether imagery/diagrams need to be updated, and whether these are included in the PR.
+ 4. Links or references evidencing that any guidance or advice is best practise (or otherwise).
+ 5. A picture of a cute animal is not mandatory, but encouraged.
+
+We'll then review the changes and use the Pull Request thread to communicate whether we're in a position to merge the contribution.
+
+<div class="alert alert-info" role="alert">
+  <h4 class="alert-heading">Contributor Licence Agreement</h4>
+  <p>
+    Before your contribution is merged to Cloudmarque we ask that you complete a <a href="http://wiki.civiccommons.org/Contributor_Agreements/">Contributor Licence Agreement</a>. This allows you to retain copyright of the contributed material while promising not to exercise typical powers that copyright implies, enabling the community to be confident that their use of Cloudmarque is free from legal encumberances.
+  </p>
+</div>
+
+Once merged, your contribution will be automatically built and published to the Cloudmarque documentation on [docs.trustmarque.com](https://docs.trustmarque.com/).


### PR DESCRIPTION
**Use case**
Instructions and guidance for internal and third-party users of Cloudmarque who wish to expand or nuance the framework with better content.

**Changes**
Two new pages in /cloudmarque/tools/docs/, updated standard CONTRIBUTING.md to point to these when built.

*No diagrams included or need to be updated*

Once published the main site nav will need to be updated to point to these pages. In the longer term, we should include the cloudmarque.yml nav file in this docs repo.

Cute animal:
![baby-skunk](https://user-images.githubusercontent.com/315626/89196786-9b96f000-d5a2-11ea-80b5-c1940465031e.jpg)
