### PR TITLE
003 minor issue sweep

### DIFF
--- a/cloudmarque/index.md
+++ b/cloudmarque/index.md
@@ -22,7 +22,7 @@ Together these represent a comprehensive conceptual model for the adoption of cl
 ## Why Cloudmarque?
 Our time spent building cloud estates for public and private sector organisations led us to develop reusable architectures, documentation, and tools. We watched as consolidation and standardisation drove efficiency and innovation in our business, and finally chose to release these tools as an open source _Cloudmarque_ project so that others could use them too.
 
-Read more about why we decided to do this over on our [Tech Blog post from our CTO, James Butler]().
+Read more about why we decided to do this over on our [Tech Blog post from our Chief Cloud Architect, Nathan Kitchen](/blog/2020/06/12/docs/).
 
 We released the original framework as Open Source because we believe quality cloud tooling is:
 

--- a/cloudmarque/index.md
+++ b/cloudmarque/index.md
@@ -6,7 +6,9 @@ use_nav: false
 ---
 ## Watch the launch event
 Cloudmarque was launched at Trustmarque's ConnectIT event in June 2020, watch Nathan Kitchen's introduction to the project!
-<iframe width="960" height="540" src="https://www.youtube.com/embed/hfLWrsArwMk" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<div class="embed-responsive embed-responsive-16by9">
+<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/hfLWrsArwMk" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
 
 ## What is it?
 Cloudmarque defines a common vocabulary (or "ubiquitous language") for discussing cloud estates, with template solutions to common problems encountered while adopting and managing cloud services.

--- a/cloudmarque/reference/commands/index.md
+++ b/cloudmarque/reference/commands/index.md
@@ -5,7 +5,7 @@ tags: tags, automation, meta
 ---
 This page is an auto-generated list of all PowerShell cmdlets in the `Cloudmarque.Azure` package.
 
-{% if site.cm-commands.length > 0 %}
+{% if site.cm-commands.size > 0 %}
 <ul>
     {% for cmd in site.cm-commands %}
     <li><a href="{{ cmd.url }}">{{ cmd.title }}</a></li>


### PR DESCRIPTION
Fixing issues in minor issue sweep.

- [X] Command index list is not enumerating commands properly
- [X]  Homepage quickstart dead link
- [X]  Reset "Summer 2020" link for Digital Platform docs
- [X] Google Search Console warning: text too small on mobile because video is not responsive